### PR TITLE
NH-10893 build docker images workflow

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -39,6 +39,8 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}_${{ matrix.os }}
+        flavor: |
+          latest=true
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v3


### PR DESCRIPTION
This PR updates the GHA `docker-images.yml` workflow to remove hardcoding of repository portion in the image name, to make the images easily available to other workflows in this repo.

Also updated to use newer versions of the official `docker` actions for tagging and build/push.

Example run https://github.com/appoptics/solarwinds-apm-ruby/actions/runs/2786288128 and resulting images https://github.com/orgs/appoptics/packages?repo_name=solarwinds-apm-ruby.