### PR TITLE
NH-10893 fix tests (again!)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -90,7 +90,7 @@ jobs:
           - 5672:5672
         options: --health-cmd "rabbitmqctl node_health_check" --health-interval 10s --health-timeout 5s --health-retries 5
       mongo:
-        image: mongo:latest
+        image: mongo:5
         ports:
           - 27017:27017
         options: "--health-cmd \"mongo --quiet --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'\" --health-interval 10s --health-timeout 5s --health-retries 5"

--- a/.github/workflows/test_on_4_linux.yml
+++ b/.github/workflows/test_on_4_linux.yml
@@ -115,7 +115,7 @@ jobs:
           - 5672:5672
         options: --health-cmd "rabbitmqctl node_health_check" --health-interval 10s --health-timeout 5s --health-retries 5
       mongo:
-        image: mongo:latest
+        image: mongo:5
         ports:
           - 27017:27017
         options: "--health-cmd \"mongo --quiet --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'\" --health-interval 10s --health-timeout 5s --health-retries 5"


### PR DESCRIPTION
# Jira
https://swicloud.atlassian.net/browse/NH-10893

# Background
Why should anything work the first time?  Right after merging #3, the `mongo:latest` image was updated to point to new major version MongoDB 6, which is breaking the service health check and not sure if anything else: https://github.com/appoptics/solarwinds-apm-ruby/actions/runs/2923255266

# Changes
Pin test MongoDB servce to version 5, which is what the local tests use and is supported until October 2024.  Tests now pass again https://github.com/appoptics/solarwinds-apm-ruby/actions/runs/2928371485