### PR TITLE
NH-20932: [skip actions] minor fix on collector env as nil

### DIFF
--- a/.github/workflows/build_for_packagecloud.yml
+++ b/.github/workflows/build_for_packagecloud.yml
@@ -32,11 +32,6 @@ jobs:
           ./autogen.sh && ./configure && make && sudo make install
           cd -
 
-      - name: Download oboe staging files from staging, compile swig wrapper
-        run: |
-          bundle exec rake fetch
-          ls -l ext/oboe_metal/src
-
       - name: Grab current version
         id: version
         run: |

--- a/lib/solarwinds_apm/oboe_init_options.rb
+++ b/lib/solarwinds_apm/oboe_init_options.rb
@@ -191,7 +191,7 @@ module SolarWindsAPM
     end
 
     def determine_the_metric_model
-      if ENV['SW_APM_COLLECTOR'].include? "appoptics.com"
+      if ENV['SW_APM_COLLECTOR']&.include? "appoptics.com"
         return 1
       else
         return 0

--- a/lib/solarwinds_apm/version.rb
+++ b/lib/solarwinds_apm/version.rb
@@ -8,7 +8,7 @@ module SolarWindsAPM
   module Version
     MAJOR  = 5 # breaking,
     MINOR  = 1 # feature,
-    PATCH  = 0 # fix => BFF
+    PATCH  = 1 # fix => BFF
     PRE    = nil # for pre-releases into packagecloud, set to nil for production releases into rubygems
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')

--- a/test/unit/oboe_init_options_test.rb
+++ b/test/unit/oboe_init_options_test.rb
@@ -157,6 +157,17 @@ describe 'OboeInitOptions' do
     _(options[22]).must_equal 0
   end
 
+  it 'checks for metric mode when sw_apm_collector is nil' do
+    ENV.delete('SW_APM_COLLECTOR')
+    ENV['SW_APM_COLLECTOR'] = nil
+    
+    SolarWindsAPM::OboeInitOptions.instance.re_init
+    options = SolarWindsAPM::OboeInitOptions.instance.array_for_oboe
+
+    _(options.size).must_equal 23
+    _(options[22]).must_equal 0
+  end
+
   it 'checks the service_key for ssl' do
     ENV.delete('SW_APM_GEM_TEST')
     ENV['SW_APM_REPORTER'] = 'ssl'

--- a/test/unit/oboe_init_options_test.rb
+++ b/test/unit/oboe_init_options_test.rb
@@ -159,7 +159,6 @@ describe 'OboeInitOptions' do
 
   it 'checks for metric mode when sw_apm_collector is nil' do
     ENV.delete('SW_APM_COLLECTOR')
-    ENV['SW_APM_COLLECTOR'] = nil
     
     SolarWindsAPM::OboeInitOptions.instance.re_init
     options = SolarWindsAPM::OboeInitOptions.instance.array_for_oboe


### PR DESCRIPTION
## Why?
When the `SW_APM_COLLECTOR` is not provided, it's allowed.

