### PR TITLE
NH-20932: using c native 

### DIFF
--- a/ext/oboe_metal/src/logging.cc
+++ b/ext/oboe_metal/src/logging.cc
@@ -51,7 +51,8 @@ bool Logging::log_profile_exit(Metadata &md, string &prof_op_id, pid_t tid,
     event->addInfo((char *)"SnapshotsOmitted", omitted, num_omitted);
 
     struct timeval tv;
-    oboe_gettimeofday(&tv);
+    struct timezone *tz = NULL;
+    gettimeofday(&tv, tz);
     event->addInfo((char *)"Timestamp_u", (long)tv.tv_sec * 1000000 + (long)tv.tv_usec);
 
     return Logging::log_profile_event(event);

--- a/ext/oboe_metal/src/logging.cc
+++ b/ext/oboe_metal/src/logging.cc
@@ -37,7 +37,8 @@ bool Logging::log_profile_entry(Metadata &md, string &prof_op_id, pid_t tid, lon
     event->addInfo((char *)"Interval", interval);
 
     struct timeval tv;
-    oboe_gettimeofday(&tv);
+    struct timezone *tz = NULL;
+    gettimeofday(&tv, tz);
     event->addInfo((char *)"Timestamp_u", (long)tv.tv_sec * 1000000 + (long)tv.tv_usec);
 
     return Logging::log_profile_event(event);

--- a/ext/oboe_metal/src/logging.h
+++ b/ext/oboe_metal/src/logging.h
@@ -8,8 +8,7 @@
 
 using namespace std;
 
-extern "C" int oboe_gettimeofday(struct timeval *tv);
-
+// extern "C" int oboe_gettimeofday(struct timeval *tv);
 
 class Logging {
    public:

--- a/ext/oboe_metal/src/profiling.cc
+++ b/ext/oboe_metal/src/profiling.cc
@@ -61,8 +61,8 @@ void print_prof_data_map() {
 
 long ts_now() {
     struct timeval tv;
-
-    oboe_gettimeofday(&tv);
+    struct timezone *tz = NULL;
+    gettimeofday(&tv, tz);
     return (long)tv.tv_sec * 1000000 + (long)tv.tv_usec;
 }
 

--- a/lib/solarwinds_apm/version.rb
+++ b/lib/solarwinds_apm/version.rb
@@ -8,7 +8,7 @@ module SolarWindsAPM
   module Version
     MAJOR  = 5 # breaking,
     MINOR  = 1 # feature,
-    PATCH  = 1 # fix => BFF
+    PATCH  = 2 # fix => BFF
     PRE    = "pre" # for pre-releases into packagecloud, set to nil for production releases into rubygems
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')


### PR DESCRIPTION
## why?
To bypass the error that oboe_gettimeofday give

## notes
Tested it on system ruby with ubuntu, centos, alpine
