### PR TITLE
NH-27837: arm support + verify_install script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @cheempz @xuan-cao-swi @tammy-baylis-swi @solarwindscloud/apm-instrumentation
+*  @solarwindscloud/apm-instrumentation

--- a/.github/workflows/scripts/_helper_run_install_tests.sh
+++ b/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+
+# Helper script to set up dependencies for the install tests, then runs the tests.
+# Accounts for:
+#   * Alpine not having bash nor agent install deps
+#   * Amazon Linux not having agent install deps
+#   * CentOS 8 being at end-of-life and needing a mirror re-point
+#   * Ubuntu not having agent install deps
+#
+# Note: centos8 can only install Python 3.8, 3.9
+
+# stop on error
+set -e
+
+echo "Install solarwinds_apm version: $SOLARWINDS_APM_VERSION"
+
+# setup dependencies quietly
+{
+    if grep Alpine /etc/os-release; then
+        # test deps
+        apk add bash
+        apk --update add ruby ruby-dev build-base nodejs tzdata postgresql-dev postgresql-client libxslt-dev libxml2-dev imagemagick
+    
+    elif grep Ubuntu /etc/os-release; then
+        ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
+        if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
+            apt-get update -y
+            apt install -y ruby ruby-dev libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+        else
+            echo "ERROR: Testing on Ubuntu <18.04 not supported."
+            exit 1
+        fi
+    elif  grep Debian /etc/os-release; then
+        debain_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
+        if [ "$debain_version" = "11" ] || [ "$debain_version" = "12" ]; then
+            apt-get update -y
+            apt install -y ruby ruby-dev libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+        else
+            echo "ERROR: Testing on Debian < 11 not supported."
+            exit 1
+        fi
+
+    fi
+} >/dev/null
+
+if [ "$MODE" = "RubyGem" ]; then
+    echo "RubyGem"
+    gem install solarwinds_apm -v "$SOLARWINDS_APM_VERSION"
+elif [ "$MODE" = "packagecloud" ]; then
+    echo "packagecloud"
+    gem install solarwinds_apm -v "$SOLARWINDS_APM_VERSION" --source https://packagecloud.io/solarwinds/solarwinds-apm-ruby/
+fi
+
+if [ "$ARITCH" = "AMD" ]; then
+    echo "AMD"
+    ruby ./scripts/test_install.rb
+elif [ "$ARITCH" = "ARM" ]; then
+    echo "ARM"
+    ruby ./.github/workflows/scripts/test_install.rb
+fi
+

--- a/.github/workflows/scripts/_helper_run_install_tests.sh
+++ b/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -6,29 +6,32 @@ set -e
 echo "Install solarwinds_apm version: $SOLARWINDS_APM_VERSION"
 
 # setup dependencies quietly
-{
-    if grep Alpine /etc/os-release; then
-        # test deps
-        apk add bash && apk --update add ruby ruby-dev build-base
+# {
+#     if grep Alpine /etc/os-release; then
+#         # test deps
+#         apk add bash && apk --update add ruby ruby-dev build-base
 
-    elif grep Ubuntu /etc/os-release; then
-        ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
-        if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
-            apt update && apt install -y ruby ruby-dev build-essential
-        else
-            echo "ERROR: Testing on Ubuntu <18.04 not supported."
-            exit 1
-        fi
-    elif  grep Debian /etc/os-release; then
-        debain_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
-        if [ "$debain_version" = "11" ] || [ "$debain_version" = "12" ]; then
-            apt update && apt install -y ruby ruby-dev build-essential
-        else
-            echo "ERROR: Testing on Debian < 11 not supported."
-            exit 1
-        fi
-    fi
-} >/dev/null
+#     elif grep Ubuntu /etc/os-release; then
+#         ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
+#         if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
+#             apt update && apt install -y ruby ruby-dev build-essential
+#         else
+#             echo "ERROR: Testing on Ubuntu <18.04 not supported."
+#             exit 1
+#         fi
+#     elif  grep Debian /etc/os-release; then
+#         debain_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
+#         if [ "$debain_version" = "11" ] || [ "$debain_version" = "12" ]; then
+#             apt update && apt install -y ruby ruby-dev build-essential
+#         else
+#             echo "ERROR: Testing on Debian < 11 not supported."
+#             exit 1
+#         fi
+#     fi
+# } >/dev/null
+
+
+rbenv local $RUBY_VERSION
 
 if [ "$MODE" = "RubyGem" ]; then
     echo "RubyGem"
@@ -38,10 +41,10 @@ elif [ "$MODE" = "packagecloud" ]; then
     gem install solarwinds_apm -v "$SOLARWINDS_APM_VERSION" --source https://packagecloud.io/solarwinds/solarwinds-apm-ruby/
 fi
 
-if [ "$ARCHITECTURE" = "AMD" ]; then
-    echo "AMD"
-    ruby ./scripts/test_install.rb
-elif [ "$ARCHITECTURE" = "ARM" ]; then
-    echo "ARM"
-    ruby ./.github/workflows/scripts/test_install.rb
-fi
+# if [ "$ARCHITECTURE" = "AMD" ]; then
+#     echo "AMD"
+#     ruby ./scripts/test_install.rb
+# elif [ "$ARCHITECTURE" = "ARM" ]; then
+#     echo "ARM"
+#     ruby ./.github/workflows/scripts/test_install.rb
+# fi

--- a/.github/workflows/scripts/_helper_run_install_tests.sh
+++ b/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -5,32 +5,30 @@ set -e
 
 echo "Install solarwinds_apm version: $SOLARWINDS_APM_VERSION"
 
-# setup dependencies quietly
-# {
-#     if grep Alpine /etc/os-release; then
-#         # test deps
-#         apk add bash && apk --update add ruby ruby-dev build-base
+{
+    if grep rhel /etc/os-release; then
+        # for special ubi now. next liboboe version we will build our own rhel image
+        yum update -y && yum install -y ruby-devel git-core gcc gcc-c++ make perl zlib-devel bzip2 openssl-devel
 
-#     elif grep Ubuntu /etc/os-release; then
-#         ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
-#         if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
-#             apt update && apt install -y ruby ruby-dev build-essential
-#         else
-#             echo "ERROR: Testing on Ubuntu <18.04 not supported."
-#             exit 1
-#         fi
-#     elif  grep Debian /etc/os-release; then
-#         debain_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
-#         if [ "$debain_version" = "11" ] || [ "$debain_version" = "12" ]; then
-#             apt update && apt install -y ruby ruby-dev build-essential
-#         else
-#             echo "ERROR: Testing on Debian < 11 not supported."
-#             exit 1
-#         fi
-#     fi
-# } >/dev/null
+        git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
+             && git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build \
+             && git clone https://github.com/rbenv/rbenv-default-gems.git ~/.rbenv/plugins/rbenv-default-gems \
+             && echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.profile \
+             && echo 'eval "$(rbenv init -)"' >> ~/.profile \
+             && echo 'eval "$(rbenv init -)"' >> ~/.bashrc \
+             && echo 'bundler' > ~/.rbenv/default-gems
 
-rbenv versions
+        echo 'alias be="bundle exec"' >> ~/.bashrc
+        echo 'alias be="bundle exec"' >> ~/.profile
+
+        . ~/.profile \
+            && cd /root/.rbenv/plugins/ruby-build && git pull && cd - \
+            && rbenv install $RUBY_VERSION
+
+        rbenv global $RUBY_VERSION
+    fi
+} >/dev/null
+
 rbenv local $RUBY_VERSION
 
 if [ "$MODE" = "RubyGem" ]; then
@@ -42,11 +40,3 @@ elif [ "$MODE" = "packagecloud" ]; then
 fi
 
 ruby ./home/.github/workflows/scripts/test_install.rb
-
-# if [ "$ARCHITECTURE" = "AMD" ]; then
-#     echo "AMD"
-#     ruby ./scripts/test_install.rb
-# elif [ "$ARCHITECTURE" = "ARM" ]; then
-#     echo "ARM"
-#     ruby ./.github/workflows/scripts/test_install.rb
-# fi

--- a/.github/workflows/scripts/_helper_run_install_tests.sh
+++ b/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -41,6 +41,8 @@ elif [ "$MODE" = "packagecloud" ]; then
     gem install solarwinds_apm -v "$SOLARWINDS_APM_VERSION" --source https://packagecloud.io/solarwinds/solarwinds-apm-ruby/
 fi
 
+ruby ./home/.github/workflows/scripts/test_install.rb
+
 # if [ "$ARCHITECTURE" = "AMD" ]; then
 #     echo "AMD"
 #     ruby ./scripts/test_install.rb

--- a/.github/workflows/scripts/_helper_run_install_tests.sh
+++ b/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env sh
 
-# Helper script to set up dependencies for the install tests, then runs the tests.
-# Accounts for:
-#   * Alpine not having bash nor agent install deps
-#   * Amazon Linux not having agent install deps
-#   * CentOS 8 being at end-of-life and needing a mirror re-point
-#   * Ubuntu not having agent install deps
-#
-# Note: centos8 can only install Python 3.8, 3.9
-
 # stop on error
 set -e
 
@@ -18,14 +9,12 @@ echo "Install solarwinds_apm version: $SOLARWINDS_APM_VERSION"
 {
     if grep Alpine /etc/os-release; then
         # test deps
-        apk add bash
-        apk --update add ruby ruby-dev build-base nodejs tzdata postgresql-dev postgresql-client libxslt-dev libxml2-dev imagemagick
-    
+        apk add bash && apk --update add ruby ruby-dev build-base
+
     elif grep Ubuntu /etc/os-release; then
         ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
         if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
-            apt-get update -y
-            apt install -y ruby ruby-dev libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+            apt update && apt install -y ruby ruby-dev build-essential
         else
             echo "ERROR: Testing on Ubuntu <18.04 not supported."
             exit 1
@@ -33,13 +22,11 @@ echo "Install solarwinds_apm version: $SOLARWINDS_APM_VERSION"
     elif  grep Debian /etc/os-release; then
         debain_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
         if [ "$debain_version" = "11" ] || [ "$debain_version" = "12" ]; then
-            apt-get update -y
-            apt install -y ruby ruby-dev libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+            apt update && apt install -y ruby ruby-dev build-essential
         else
             echo "ERROR: Testing on Debian < 11 not supported."
             exit 1
         fi
-
     fi
 } >/dev/null
 
@@ -51,11 +38,10 @@ elif [ "$MODE" = "packagecloud" ]; then
     gem install solarwinds_apm -v "$SOLARWINDS_APM_VERSION" --source https://packagecloud.io/solarwinds/solarwinds-apm-ruby/
 fi
 
-if [ "$ARITCH" = "AMD" ]; then
+if [ "$ARCHITECTURE" = "AMD" ]; then
     echo "AMD"
     ruby ./scripts/test_install.rb
-elif [ "$ARITCH" = "ARM" ]; then
+elif [ "$ARCHITECTURE" = "ARM" ]; then
     echo "ARM"
     ruby ./.github/workflows/scripts/test_install.rb
 fi
-

--- a/.github/workflows/scripts/_helper_run_install_tests.sh
+++ b/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -30,7 +30,7 @@ echo "Install solarwinds_apm version: $SOLARWINDS_APM_VERSION"
 #     fi
 # } >/dev/null
 
-
+rbenv versions
 rbenv local $RUBY_VERSION
 
 if [ "$MODE" = "RubyGem" ]; then

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -18,8 +18,8 @@ on:
 
 env:
   SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
-  SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
-  SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+  SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
+  SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR_PROD }}
   PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
             MODE: ${{ github.event.inputs.install-registry }}
             ARITCH: ARM
             SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
-            SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
-            SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+            SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
+            SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR_PROD }}
             PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -2,43 +2,73 @@ name: Verify Installation
 
 on:
   workflow_dispatch:
+    inputs:
+      install-registry:
+        required: true
+        description: 'Registry used for install tests, e.g. RubyGem, packagecloud'
+        type: choice
+        default: 'RubyGem'
+        options:
+        - RubyGem
+        - packagecloud
 
+      solarwinds-version:
+        required: true
+        description: 'Solarwinds apm version'
 
 env:
-  SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
-  SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR_PROD}}
+  SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
+  SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+  SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+  PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
 jobs:
-  #--------------------------------------------------------------------
-  # RUBY 3.1
-  #--------------------------------------------------------------------
 
-  ruby31_install_ubuntu_20:
+  verify_install_amd64_test:
+    name: ruby - ${{ matrix.os }} amd64 - ${{ github.event.inputs.solarwinds-version }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [3.1.3-bullseye, 2.7.7-bullseye, 3.1.3-alpine3.17, 2.7.7-alpine3.16]
+
     container:
-      image: ruby:3.1.3-bullseye
+      image: ruby:${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup and run install test
         working-directory: .github/workflows/
-        run: |
-          sleep 1
-          gem install solarwinds_apm
-          ruby ./scripts/test_install.rb
+        run: ./scripts/_helper_run_install_tests.sh
+        shell: sh
+        env:
+          MODE: ${{ github.event.inputs.install-registry }}
+          ARITCH: AMD
 
-  ruby31_install_ubuntu_20_arm:
+  verify_install_arm64_test:
+    name: ruby - ${{ matrix.os }} amd64 - ${{ github.event.inputs.solarwinds-version }}
     runs-on: ubuntu-latest
-    container:
-      image: arm64v8/ruby:3.1.3-bullseye
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [bullseye, ubuntu20.04, ubuntu18.04, alpine_latest]
+
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
       - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2
+        name: Verify Install
+        with:
+          arch: aarch64
+          distro: ${{ matrix.os }}
+          run: |
+            ./.github/workflows/scripts/_helper_run_install_tests.sh
+          env: |
+            MODE: ${{ github.event.inputs.install-registry }}
+            ARITCH: ARM
+            SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
+            SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+            SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+            PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
-      - name: Setup and run install test
-        working-directory: .github/workflows/
-        run: |
-          sleep 1
-          gem install solarwinds_apm
-          ruby ./scripts/test_install.rb

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -35,7 +35,7 @@ jobs:
         ruby_version: ['3.1.0', '2.7.5']
 
     container:
-      image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
+      image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:main
 
     steps:
       - uses: actions/checkout@v2
@@ -67,8 +67,8 @@ jobs:
       - name: Log in to the Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: docker pull --platform linux/arm64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, alpine]
-        ruby_version: [3.1.0, 2.7.5]
+        ruby_version: ['3.1.0', '2.7.5']
 
     container:
       image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
@@ -58,11 +58,18 @@ jobs:
       matrix:
         # list of supported platform: https://github.com/uraimo/run-on-arch-action#supported-platforms
         os: [ubuntu, alpine]
-        ruby_version: [3.1.0, 2.7.5]
+        ruby_version: ['3.1.0', '2.7.5']
 
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
+
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: docker pull --platform linux/arm64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
       

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -31,22 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, alpine]
+        os: [ubuntu, alpine, centos]
         ruby_version: ['3.1.0', '2.7.5']
-
-    # container:
-    #   image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:main
-
-    # steps:
-    #   - uses: actions/checkout@v2
-    #   - name: Setup and run install test
-    #     working-directory: .github/workflows/
-    #     run: ./scripts/_helper_run_install_tests.sh
-    #     shell: sh
-    #     env:
-    #       MODE: ${{ github.event.inputs.install-registry }}
-    #       ARCHITECTURE: AMD
-    #       RUBY_VERSION: ${{ matrix.ruby_version }}
     steps:
       - uses: actions/checkout@v3
 
@@ -82,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, alpine]
+        os: [ubuntu, alpine, centos]
         ruby_version: ['3.1.0', '2.7.5']
 
     steps:
@@ -112,13 +98,3 @@ jobs:
             -v $(pwd):/home \
             --rm ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b \
             ./home/.github/workflows/scripts/_helper_run_install_tests.sh
-
-
-
-
-
-
-
-
-
-

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, alpine, centos]
+        os: [ubuntu, alpine]
         ruby_version: ['3.1.0', '2.7.5']
     steps:
       - uses: actions/checkout@v3
@@ -62,13 +62,13 @@ jobs:
 
 
   verify_install_arm64_test:
-    name: ruby - ${{ matrix.os }} arm64 - ${{ github.event.inputs.solarwinds-version }}
+    name: ruby - ${{ matrix.ruby_version }} - ${{ matrix.os }} arm64 - ${{ github.event.inputs.solarwinds-version }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, alpine, centos]
+        os: [ubuntu, alpine]
         ruby_version: ['3.1.0', '2.7.5']
 
     steps:
@@ -98,3 +98,55 @@ jobs:
             -v $(pwd):/home \
             --rm ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b \
             ./home/.github/workflows/scripts/_helper_run_install_tests.sh
+
+  verify_install_ubi8_amd64_test:
+    name: ruby - ${{ matrix.ruby_version }} - ubi8 amd64 - ${{ github.event.inputs.solarwinds-version }}
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: [3.1.0, 2.7.5]
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker pull redhat/ubi8
+      - name: Run tests in container
+        run: |
+          sudo docker run \
+            --platform linux/amd64 \
+            -e RUBY_VERSION=${{ matrix.ruby_version }} \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
+            -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
+            -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
+            -v $(pwd):/home \
+            --rm redhat/ubi8 \
+            ./home/full_install_rhel.sh
+
+  verify_install_ubi8_arm64_test:
+    name: ruby - ${{ matrix.ruby_version }} - ubi8 arm64 - ${{ github.event.inputs.solarwinds-version }}
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: [3.1.0, 2.7.5]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - run: docker pull --platform linux/arm64 redhat/ubi8
+      - name: Run tests in container
+        run: |
+          sudo docker run \
+            --platform linux/arm64 \
+            -e RUBY_VERSION=${{ matrix.ruby_version }} \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
+            -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
+            -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
+            -v $(pwd):/home \
+            --rm redhat/ubi8 \
+            ./home/full_install_rhel.sh
+

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -16,12 +16,6 @@ on:
         required: true
         description: 'Solarwinds apm version'
 
-env:
-  SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
-  SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
-  SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR_PROD }}
-  PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-
 jobs:
 
   verify_install_amd64_test:
@@ -54,7 +48,6 @@ jobs:
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -e MODE=${{ github.event.inputs.install-registry }} \
-            -e ARCHITECTURE=AMD \
             -e RUBY_VERSION=${{ matrix.ruby_version }} \
             -v $(pwd):/home \
             --rm ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b \
@@ -93,7 +86,6 @@ jobs:
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -e MODE=${{ github.event.inputs.install-registry }} \
-            -e ARCHITECTURE=AMD \
             -e RUBY_VERSION=${{ matrix.ruby_version }} \
             -v $(pwd):/home \
             --rm ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b \
@@ -120,6 +112,7 @@ jobs:
             -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
+            -e MODE=${{ github.event.inputs.install-registry }} \
             -v $(pwd):/home \
             --rm redhat/ubi8 \
             ./home/.github/workflows/scripts/_helper_run_install_tests.sh
@@ -146,6 +139,7 @@ jobs:
             -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
+            -e MODE=${{ github.event.inputs.install-registry }} \
             -v $(pwd):/home \
             --rm redhat/ubi8 \
             ./home/.github/workflows/scripts/_helper_run_install_tests.sh

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -122,7 +122,7 @@ jobs:
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -v $(pwd):/home \
             --rm redhat/ubi8 \
-            ./home/full_install_rhel.sh
+            ./home/.github/workflows/scripts/_helper_run_install_tests.sh
 
   verify_install_ubi8_arm64_test:
     name: ruby - ${{ matrix.ruby_version }} - ubi8 arm64 - ${{ github.event.inputs.solarwinds-version }}
@@ -148,5 +148,5 @@ jobs:
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -v $(pwd):/home \
             --rm redhat/ubi8 \
-            ./home/full_install_rhel.sh
+            ./home/.github/workflows/scripts/_helper_run_install_tests.sh
 

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -25,16 +25,17 @@ env:
 jobs:
 
   verify_install_amd64_test:
-    name: ruby - ${{ matrix.os }} amd64 - ${{ github.event.inputs.solarwinds-version }}
+    name: ruby - ${{ matrix.ruby_version }} - ${{ matrix.os }} amd64 - ${{ github.event.inputs.solarwinds-version }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        os: [3.1.3-bullseye, 2.7.7-bullseye, 3.1.3-alpine3.17, 2.7.7-alpine3.16]
+        os: [ubuntu, alpine]
+        ruby_version: [3.1.0, 2.7.5]
 
     container:
-      image: ruby:${{ matrix.os }}
+      image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
 
     steps:
       - uses: actions/checkout@v2
@@ -45,6 +46,8 @@ jobs:
         env:
           MODE: ${{ github.event.inputs.install-registry }}
           ARCHITECTURE: AMD
+          RUBY_VERSION: ${{ matrix.ruby_version }}
+
 
   verify_install_arm64_test:
     name: ruby - ${{ matrix.os }} arm64 - ${{ github.event.inputs.solarwinds-version }}
@@ -54,22 +57,36 @@ jobs:
       fail-fast: false
       matrix:
         # list of supported platform: https://github.com/uraimo/run-on-arch-action#supported-platforms
-        os: [bullseye, ubuntu20.04, ubuntu18.04, alpine_latest]
+        os: [ubuntu, alpine]
+        ruby_version: [3.1.0, 2.7.5]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: uraimo/run-on-arch-action@v2
-        name: Verify Install
-        with:
-          arch: aarch64
-          distro: ${{ matrix.os }}
-          run: |
-            ./.github/workflows/scripts/_helper_run_install_tests.sh
-          env: |
-            MODE: ${{ github.event.inputs.install-registry }}
-            ARCHITECTURE: ARM
-            SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
-            SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
-            SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR_PROD }}
-            PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+
+      - run: docker pull --platform linux/arm64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
+      
+      - name: Run tests in container using QEMU
+        run: |
+          sudo docker run \
+            --platform linux/arm64 \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
+            -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
+            -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
+            -e MODE=${{ github.event.inputs.install-registry }} \
+            -e ARCHITECTURE=AMD \
+            -e RUBY_VERSION=${{ matrix.ruby_version }} \
+            -v $(pwd):/home \
+            --rm ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b \
+            ./home/.github/workflows/scripts/_helper_run_install_tests.sh
+
+
+
+
+
+
+
+
+
 

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -37,9 +37,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: docker pull --platform linux/amd64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
+      - run: docker pull --platform linux/amd64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:latest
       
-      - name: Run tests in container using QEMU
+      - name: Run tests in container
         run: |
           sudo docker run \
             --platform linux/amd64 \
@@ -75,7 +75,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: docker pull --platform linux/arm64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
+      - run: docker pull --platform linux/arm64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:latest
       
       - name: Run tests in container using QEMU
         run: |
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: docker pull redhat/ubi8
-      - name: Run tests in container
+      - name: Run tests in ubi8 container
         run: |
           sudo docker run \
             --platform linux/amd64 \
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
       - run: docker pull --platform linux/arm64 redhat/ubi8
-      - name: Run tests in container
+      - name: Run tests in ubi8 container using QEMU
         run: |
           sudo docker run \
             --platform linux/arm64 \

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -34,19 +34,45 @@ jobs:
         os: [ubuntu, alpine]
         ruby_version: ['3.1.0', '2.7.5']
 
-    container:
-      image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:main
+    # container:
+    #   image: ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:main
 
+    # steps:
+    #   - uses: actions/checkout@v2
+    #   - name: Setup and run install test
+    #     working-directory: .github/workflows/
+    #     run: ./scripts/_helper_run_install_tests.sh
+    #     shell: sh
+    #     env:
+    #       MODE: ${{ github.event.inputs.install-registry }}
+    #       ARCHITECTURE: AMD
+    #       RUBY_VERSION: ${{ matrix.ruby_version }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup and run install test
-        working-directory: .github/workflows/
-        run: ./scripts/_helper_run_install_tests.sh
-        shell: sh
-        env:
-          MODE: ${{ github.event.inputs.install-registry }}
-          ARCHITECTURE: AMD
-          RUBY_VERSION: ${{ matrix.ruby_version }}
+      - uses: actions/checkout@v3
+
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: docker pull --platform linux/amd64 ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b
+      
+      - name: Run tests in container using QEMU
+        run: |
+          sudo docker run \
+            --platform linux/amd64 \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY_PROD }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR_PROD }} \
+            -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
+            -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
+            -e MODE=${{ github.event.inputs.install-registry }} \
+            -e ARCHITECTURE=AMD \
+            -e RUBY_VERSION=${{ matrix.ruby_version }} \
+            -v $(pwd):/home \
+            --rm ghcr.io/${{ github.repository }}/apm_ruby_${{ matrix.os }}:nh-27837-b \
+            ./home/.github/workflows/scripts/_helper_run_install_tests.sh
 
 
   verify_install_arm64_test:
@@ -56,7 +82,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # list of supported platform: https://github.com/uraimo/run-on-arch-action#supported-platforms
         os: [ubuntu, alpine]
         ruby_version: ['3.1.0', '2.7.5']
 
@@ -77,8 +102,8 @@ jobs:
         run: |
           sudo docker run \
             --platform linux/arm64 \
-            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY }} \
-            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY_PROD }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR_PROD }} \
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -e MODE=${{ github.event.inputs.install-registry }} \

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -108,8 +108,8 @@ jobs:
           sudo docker run \
             --platform linux/amd64 \
             -e RUBY_VERSION=${{ matrix.ruby_version }} \
-            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY }} \
-            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY_PROD }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR_PROD }} \
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -e MODE=${{ github.event.inputs.install-registry }} \
@@ -135,8 +135,8 @@ jobs:
           sudo docker run \
             --platform linux/arm64 \
             -e RUBY_VERSION=${{ matrix.ruby_version }} \
-            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY }} \
-            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR }} \
+            -e SW_APM_SERVICE_KEY=${{ secrets.SW_APM_SERVICE_KEY_PROD }} \
+            -e SW_APM_COLLECTOR=${{ secrets.SW_APM_COLLECTOR_PROD }} \
             -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
             -e PACKAGECLOUD_TOKEN=${{ secrets.PACKAGECLOUD_TOKEN }} \
             -e MODE=${{ github.event.inputs.install-registry }} \

--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -44,15 +44,16 @@ jobs:
         shell: sh
         env:
           MODE: ${{ github.event.inputs.install-registry }}
-          ARITCH: AMD
+          ARCHITECTURE: AMD
 
   verify_install_arm64_test:
-    name: ruby - ${{ matrix.os }} amd64 - ${{ github.event.inputs.solarwinds-version }}
+    name: ruby - ${{ matrix.os }} arm64 - ${{ github.event.inputs.solarwinds-version }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
+        # list of supported platform: https://github.com/uraimo/run-on-arch-action#supported-platforms
         os: [bullseye, ubuntu20.04, ubuntu18.04, alpine_latest]
 
     steps:
@@ -66,7 +67,7 @@ jobs:
             ./.github/workflows/scripts/_helper_run_install_tests.sh
           env: |
             MODE: ${{ github.event.inputs.install-registry }}
-            ARITCH: ARM
+            ARCHITECTURE: ARM
             SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
             SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
             SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR_PROD }}

--- a/ext/oboe_metal/extconf.rb
+++ b/ext/oboe_metal/extconf.rb
@@ -37,15 +37,24 @@ else
   ao_path = File.join('https://agent-binaries.cloud.solarwinds.com/apm/c-lib/', version)
 end
 
-ao_arch = 'x86_64'
+ao_arch = "x86_64"
+system_arch = `uname -m` # for mac, the command is `uname` # "Darwin\n"; try `uname -a`
+case system_arch.gsub("\n","")
+when "x86_64"
+  ao_arch = "x86_64"
+when "aarch64"
+  ao_arch = "aarch64"
+end
+
 if File.exist?('/etc/alpine-release')
   version = File.read('/etc/alpine-release').strip
 
+  tmp_ao_arch = ao_arch.clone
   ao_arch =
     if Gem::Version.new(version) < Gem::Version.new('3.9')
-      'alpine-libressl-x86_64'
+      "alpine-libressl-#{tmp_ao_arch}"
     else # openssl
-      'alpine-x86_64'
+      "alpine-#{tmp_ao_arch}"
     end
 end
 


### PR DESCRIPTION
## Why?

Trimmed [pr](https://github.com/solarwindscloud/solarwinds-apm-ruby/pull/20) version only for verify_install script and extconf.rb change.

## Extra

Successful verify install gha [here](https://github.com/solarwindscloud/solarwinds-apm-ruby/actions/runs/3884288475)