### PR TITLE
[skip actions] NH-26618: update init msg for swo

### DIFF
--- a/lib/solarwinds_apm/util.rb
+++ b/lib/solarwinds_apm/util.rb
@@ -265,57 +265,68 @@ module SolarWindsAPM
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 
       ##
-      #  build_init_report
+      # build_legacy_ao_init_report
       #
       # Internal: Build a hash of KVs that reports on the status of the
       # running environment.  This is used on stack boot in __Init reporting
       # and for SolarWindsAPM.support_report.
+      # On 2023-01-12, this is no longer used in new SWO endpoints
+      #
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+      def build_legacy_ao_init_report
+        platform_info = { '__Init' => 1 }
+        begin
+          platform_info['Force']                                = true
+          platform_info['Ruby.Platform.Version']                = RUBY_PLATFORM
+          platform_info['Ruby.Version']                         = RUBY_VERSION
+          platform_info['Ruby.SolarWindsAPM.Version']       = SolarWindsAPM::Version::STRING
+          platform_info['Ruby.SolarWindsAPMExtension.Version'] = get_extension_lib_version
+          platform_info['RubyHeroku.SolarWindsAPM.Version']    = SolarWindsAPMHeroku::Version::STRING if defined?(SolarWindsAPMHeroku)
+          platform_info['Ruby.TraceMode.Version']                  = SolarWindsAPM::Config[:tracing_mode]
+          platform_info.merge!(report_gem_in_use)
+          platform_info.merge!(report_server_in_use)
+
+        rescue StandardError, ScriptError => e
+          platform_info['Error'] = "Error in build_report: #{e.message}"
+          SolarWindsAPM.logger.warn "[solarwinds_apm/warn] Error in build_init_report: #{e.message}"
+          SolarWindsAPM.logger.debug e.backtrace
+        end
+        platform_info
+      end
+
+      ##
+      #  build_swo_init_report
+      #
+      # Internal: Build a hash of KVs that reports on the status of the
+      # running environment for swo only. This is used on stack boot in __Init reporting
+      # and for SolarWindsAPM.support_report.
       #
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
       def build_init_report
-        platform_info = { '__Init' => 1 }
+
+        platform_info = { '__Init' => true }
 
         begin
-          platform_info['Force']                        = true
-          platform_info['Ruby.Platform.Version']        = RUBY_PLATFORM
-          platform_info['Ruby.Version']                 = RUBY_VERSION
-          platform_info['Ruby.SolarWindsAPM.Version']       = SolarWindsAPM::Version::STRING
+          platform_info['APM.Version']                  = SolarWindsAPM::Version::STRING
+          platform_info['APM.Extension.Version']        = get_extension_lib_version
+          
+          platform_info['process.pid']                  = Process.pid
+          platform_info['process.command']              = $PROGRAM_NAME
+          platform_info['process.runtime.name']         = RUBY_ENGINE
+          platform_info['process.runtime.version']      = RUBY_VERSION
+          platform_info['process.runtime.description']  = RUBY_DESCRIPTION
+          platform_info['telemetry.sdk.language']       = nil
 
-          # oboe not loaded yet, can't use oboe_api function to read oboe VERSION
-          clib_version_file = File.join(Gem::Specification.find_by_name('solarwinds_apm').gem_dir, 'ext', 'oboe_metal', 'src', 'VERSION')
-          platform_info['Ruby.SolarWindsAPMExtension.Version'] = File.read(clib_version_file).strip
-          platform_info['RubyHeroku.SolarWindsAPM.Version'] = SolarWindsAPMHeroku::Version::STRING if defined?(SolarWindsAPMHeroku)
-          platform_info['Ruby.TraceMode.Version']          = SolarWindsAPM::Config[:tracing_mode]
+          # Resource Attributes (Optional)
+          platform_info['process.executable.path'] = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']).sub(/.*\s.*/m, '"\&"')
+          platform_info['process.executable.name'] = RbConfig::CONFIG['ruby_install_name']
+          platform_info['process.command_line']    = $PROGRAM_NAME
+          platform_info['process.telemetry.path']  = Gem::Specification.find_by_name('solarwinds_apm')&.full_gem_path
+          platform_info['os.type']                 = RUBY_PLATFORM
+          platform_info['os.description']          = `uname -a`.gsub("\n","")
+          # platform_info['process.detailed_command_line'] = `ps axw`.split("\n").select{ |ps| ps[ /\A#{ $$ }/ ] }[0]
 
-          # Collect up the loaded gems
-          if defined?(Gem) && Gem.respond_to?(:loaded_specs)
-            Gem.loaded_specs.each_pair { |k, v|
-              platform_info["Ruby.#{k}.Version"] = v.version.to_s
-            }
-          else
-            platform_info.merge!(legacy_build_init_report)
-          end
-
-          # Report the server in use (if possible)
-          if defined?(::Unicorn::Const::UNICORN_VERSION)
-            platform_info['Ruby.AppContainer.Version'] = "Unicorn-#{::Unicorn::Const::UNICORN_VERSION}"
-          elsif defined?(::Puma::Const::PUMA_VERSION)
-            platform_info['Ruby.AppContainer.Version'] = "Puma-#{::Puma::Const::PUMA_VERSION} (#{::Puma::Const::CODE_NAME})"
-          elsif defined?(::PhusionPassenger::PACKAGE_NAME)
-            platform_info['Ruby.AppContainer.Version'] = "#{::PhusionPassenger::PACKAGE_NAME}-#{::PhusionPassenger::VERSION_STRING}"
-          elsif defined?(::Thin::VERSION::STRING)
-            platform_info['Ruby.AppContainer.Version'] = "Thin-#{::Thin::VERSION::STRING} (#{::Thin::VERSION::CODENAME})"
-          elsif defined?(::Mongrel::Const::MONGREL_VERSION)
-            platform_info['Ruby.AppContainer.Version'] = "Mongrel-#{::Mongrel::Const::MONGREL_VERSION}"
-          elsif defined?(::Mongrel2::VERSION)
-            platform_info['Ruby.AppContainer.Version'] = "Mongrel2-#{::Mongrel2::VERSION}"
-          elsif defined?(::Trinidad::VERSION)
-            platform_info['Ruby.AppContainer.Version'] = "Trinidad-#{::Trinidad::VERSION}"
-          elsif defined?(::WEBrick::VERSION)
-            platform_info['Ruby.AppContainer.Version'] = "WEBrick-#{::WEBrick::VERSION}"
-          else
-            platform_info['Ruby.AppContainer.Version'] = File.basename($PROGRAM_NAME)
-          end
+          platform_info.merge!(report_gem_in_use)
 
         rescue StandardError, ScriptError => e
           # Also rescue ScriptError (aka SyntaxError) in case one of the expected
@@ -329,6 +340,71 @@ module SolarWindsAPM
         platform_info
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
+
+      private
+
+      ##
+      # Collect up the loaded gems
+      ##
+      def report_gem_in_use
+        platform_info = {}
+        if defined?(Gem) && Gem.respond_to?(:loaded_specs)
+          Gem.loaded_specs.each_pair { |k, v|
+            platform_info["Ruby.#{k}.Version"] = v.version.to_s
+          }
+        else
+          platform_info.merge!(legacy_build_init_report)
+        end
+        platform_info
+      end
+
+      ##
+      # get extension library version by looking at the VERSION file
+      # oboe not loaded yet, can't use oboe_api function to read oboe VERSION
+      ##
+      def get_extension_lib_version
+        version = '0.0.0'
+        begin
+          gem_location = Gem::Specification.find_by_name('solarwinds_apm')
+          clib_version_file = File.join(gem_location&.gem_dir, 'ext', 'oboe_metal', 'src', 'VERSION')
+          version = File.read(clib_version_file).strip
+        rescue
+          SolarWindsAPM.logger.warn "[solarwinds_apm/warn] Error in build_init_report: couldn't find installed solarwinds_apm gem #{e.message}"
+        end
+        version
+      end
+
+      ##
+      # build_init_report
+      #
+      # Internal: Build a hash of KVs that reports on the server in use
+      ##
+      def report_server_in_use
+        platform_info = {}
+        # Report the server in use (if possible)
+        if defined?(::Unicorn::Const::UNICORN_VERSION)
+          platform_info['Ruby.AppContainer.Version'] = "Unicorn-#{::Unicorn::Const::UNICORN_VERSION}"
+        elsif defined?(::Puma::Const::PUMA_VERSION)
+          platform_info['Ruby.AppContainer.Version'] = "Puma-#{::Puma::Const::PUMA_VERSION} (#{::Puma::Const::CODE_NAME})"
+        elsif defined?(::PhusionPassenger::PACKAGE_NAME)
+          platform_info['Ruby.AppContainer.Version'] = "#{::PhusionPassenger::PACKAGE_NAME}-#{::PhusionPassenger::VERSION_STRING}"
+        elsif defined?(::Thin::VERSION::STRING)
+          platform_info['Ruby.AppContainer.Version'] = "Thin-#{::Thin::VERSION::STRING} (#{::Thin::VERSION::CODENAME})"
+        elsif defined?(::Mongrel::Const::MONGREL_VERSION)
+          platform_info['Ruby.AppContainer.Version'] = "Mongrel-#{::Mongrel::Const::MONGREL_VERSION}"
+        elsif defined?(::Mongrel2::VERSION)
+          platform_info['Ruby.AppContainer.Version'] = "Mongrel2-#{::Mongrel2::VERSION}"
+        elsif defined?(::Trinidad::VERSION)
+          platform_info['Ruby.AppContainer.Version'] = "Trinidad-#{::Trinidad::VERSION}"
+        elsif defined?(::WEBrick::VERSION)
+          platform_info['Ruby.AppContainer.Version'] = "WEBrick-#{::WEBrick::VERSION}"
+        else
+          platform_info['Ruby.AppContainer.Version'] = File.basename($PROGRAM_NAME)
+        end
+        platform_info
+      end
+
     end
+
   end
 end

--- a/lib/solarwinds_apm/util.rb
+++ b/lib/solarwinds_apm/util.rb
@@ -279,10 +279,10 @@ module SolarWindsAPM
           platform_info['Force']                                = true
           platform_info['Ruby.Platform.Version']                = RUBY_PLATFORM
           platform_info['Ruby.Version']                         = RUBY_VERSION
-          platform_info['Ruby.SolarWindsAPM.Version']       = SolarWindsAPM::Version::STRING
-          platform_info['Ruby.SolarWindsAPMExtension.Version'] = get_extension_lib_version
-          platform_info['RubyHeroku.SolarWindsAPM.Version']    = SolarWindsAPMHeroku::Version::STRING if defined?(SolarWindsAPMHeroku)
-          platform_info['Ruby.TraceMode.Version']                  = SolarWindsAPM::Config[:tracing_mode]
+          platform_info['Ruby.SolarWindsAPM.Version']           = SolarWindsAPM::Version::STRING
+          platform_info['Ruby.SolarWindsAPMExtension.Version']  = get_extension_lib_version
+          platform_info['RubyHeroku.SolarWindsAPM.Version']     = SolarWindsAPMHeroku::Version::STRING if defined?(SolarWindsAPMHeroku)
+          platform_info['Ruby.TraceMode.Version']               = SolarWindsAPM::Config[:tracing_mode]
           platform_info.merge!(report_gem_in_use)
           platform_info.merge!(report_server_in_use)
 
@@ -315,7 +315,7 @@ module SolarWindsAPM
           platform_info['process.runtime.name']         = RUBY_ENGINE
           platform_info['process.runtime.version']      = RUBY_VERSION
           platform_info['process.runtime.description']  = RUBY_DESCRIPTION
-          platform_info['telemetry.sdk.language']       = nil
+          platform_info['telemetry.sdk.language']       = 'ruby'
 
           # Resource Attributes (Optional)
           platform_info['process.executable.path'] = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']).sub(/.*\s.*/m, '"\&"')

--- a/test/support/init_report_test.rb
+++ b/test/support/init_report_test.rb
@@ -4,24 +4,26 @@
 require 'minitest_helper'
 
 describe 'InitReportTest' do
-   it 'report_format' do
+
+  it 'report_format' do
     init_kvs = ::SolarWindsAPM::Util.build_init_report
     init_kvs.is_a?(Hash)
   end
 
-   it 'report_kvs' do
+  it 'report_kvs' do
     init_kvs = ::SolarWindsAPM::Util.build_init_report
+
     _(init_kvs.has_key?("__Init")).must_equal true
-    _(init_kvs.has_key?("Force")).must_equal false # removed for swo
-    _(init_kvs.has_key?("Ruby.AppContainer.Version")).must_equal true
-    _(init_kvs["Ruby.SolarWindsAPM.Version"]).must_equal SolarWindsAPM::Version::STRING
-    _(init_kvs["Ruby.SolarWindsAPMExtension.Version"]).must_equal Oboe_metal::Config.getVersionString
-    _(init_kvs["Ruby.TraceMode.Version"]).must_equal SolarWindsAPM::Config[:tracing_mode]
-  end
+    _(init_kvs.has_key?("process.pid")).must_equal true
+    _(init_kvs.has_key?("process.command")).must_equal true
+    _(init_kvs.has_key?("process.runtime.name")).must_equal true
+    _(init_kvs.has_key?("process.runtime.version")).must_equal true
+    _(init_kvs.has_key?("process.runtime.description")).must_equal true
+    _(init_kvs.has_key?("process.command")).must_equal true
 
-  # @deprecated
-   it 'legacy_report_format' do
-    init_kvs = ::SolarWindsAPM::Util.legacy_build_init_report
-    init_kvs.is_a?(Hash)
+    _(init_kvs["__Init"]).must_equal true
+    _(init_kvs["APM.Version"]).must_equal SolarWindsAPM::Version::STRING
+    _(init_kvs["APM.Extension.Version"]).must_equal Oboe_metal::Config.getVersionString
+    _(init_kvs["telemetry.sdk.language"]).must_equal "ruby"
   end
 end

--- a/test/support/init_report_test.rb
+++ b/test/support/init_report_test.rb
@@ -12,7 +12,7 @@ describe 'InitReportTest' do
    it 'report_kvs' do
     init_kvs = ::SolarWindsAPM::Util.build_init_report
     _(init_kvs.has_key?("__Init")).must_equal true
-    _(init_kvs.has_key?("Force")).must_equal true
+    _(init_kvs.has_key?("Force")).must_equal false # removed for swo
     _(init_kvs.has_key?("Ruby.AppContainer.Version")).must_equal true
     _(init_kvs["Ruby.SolarWindsAPM.Version"]).must_equal SolarWindsAPM::Version::STRING
     _(init_kvs["Ruby.SolarWindsAPMExtension.Version"]).must_equal Oboe_metal::Config.getVersionString


### PR DESCRIPTION
## Why?

To update the __init msg based on the [requirements](https://github.com/librato/trace/blob/master/docs/specs/KV/init.md#swo)

## Impact

Changed msg
```
{"__Init"=>true,                                                                                   
 "APM.Version"=>"5.1.4",                                                                           
 "APM.Extension.Version"=>"11.1.0",                                                                
 "process.pid"=>28128,                                                                             
 "process.command"=>"irb",                                                                         
 "process.runtime.name"=>"ruby",                                                                   
 "process.runtime.version"=>"2.7.5",                                                               
 "process.runtime.description"=>"ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux]",  
 "telemetry.sdk.language"=>nil,                                                                    
 "process.executable.path"=>"/root/.rbenv/versions/2.7.5/bin/ruby",                                
 "process.executable.name"=>"ruby",                                                                
 "process.command_line"=>"irb",                                                                    
 "process.telemetry.path"=>"/root/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/solarwinds_apm-5.1.4",
 "os.type"=>"x86_64-linux",                                           
 "os.description"=>"Linux docker.ao.ubuntu 5.15.49-linuxkit #1 SMP PREEMPT Tue Sep 13 07:51:32 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux",
 "Ruby.did_you_mean.Version"=>"1.4.0",
 "Ruby.reline.Version"=>"0.3.2",
 "Ruby.irb.Version"=>"1.6.2",
 "Ruby.uri.Version"=>"0.10.0",
 "Ruby.io-console.Version"=>"0.6.0",
 "Ruby.timeout.Version"=>"0.1.0",
 "Ruby.forwardable.Version"=>"1.3.1",
 "Ruby.delegate.Version"=>"0.1.0",
 "Ruby.fileutils.Version"=>"1.4.1",
 "Ruby.etc.Version"=>"1.1.0",
 "Ruby.fiddle.Version"=>"1.0.0",
 "Ruby.rdoc.Version"=>"6.2.1.1",
 "Ruby.readline.Version"=>"0.0.2",
 "Ruby.readline-ext.Version"=>"0.1.0",
 "Ruby.date.Version"=>"3.0.3",
 "Ruby.cgi.Version"=>"0.1.0.1",
 "Ruby.strscan.Version"=>"1.0.3",
 "Ruby.no_proxy_fix.Version"=>"0.1.2",
 "Ruby.solarwinds_apm.Version"=>"5.1.4",
 "Ruby.ipaddr.Version"=>"1.2.2",
 "Ruby.openssl.Version"=>"2.1.3",
 "Ruby.stringio.Version"=>"0.1.0",
 "Ruby.logger.Version"=>"1.4.2",
 "Ruby.singleton.Version"=>"0.1.0",
 "Ruby.json.Version"=>"2.6.3",
 "Ruby.ostruct.Version"=>"0.2.0",
 "Ruby.zlib.Version"=>"1.1.0"}
```
