### PR TITLE
NH-34066: sanitize uri for disgarding username and password

### DIFF
--- a/gemfiles/test_gems.gemfile
+++ b/gemfiles/test_gems.gemfile
@@ -17,7 +17,13 @@ group :development, :test do
   gem 'minitest-hooks', '>= 1.5.0'
   gem 'minitest-reporters', '< 1.0.18'
   gem 'mocha'
-  gem 'puma'
+
+  if RUBY_VERSION <= '2.7.5'
+    gem 'puma', '<= 6.0.2'
+  else
+    gem 'puma'
+  end
+  
   gem 'rack-cache'
   gem 'rack-test'
   gem 'rake'

--- a/lib/solarwinds_apm/inst/curb.rb
+++ b/lib/solarwinds_apm/inst/curb.rb
@@ -30,6 +30,7 @@ module SolarWindsAPM
           kvs[:RemoteURL] = url.split('?').first
         end
 
+        kvs[:RemoteURL] = SolarWindsAPM::Util.sanitize_uri(kvs[:RemoteURL])
         kvs[:HTTPMethod] = verb if verb
 
         kvs

--- a/lib/solarwinds_apm/inst/httpclient.rb
+++ b/lib/solarwinds_apm/inst/httpclient.rb
@@ -23,6 +23,7 @@ module SolarWindsAPM
           kvs[:RemoteURL] = uri.to_s.split('?').first
         end
 
+        kvs[:RemoteURL] = SolarWindsAPM::Util.sanitize_uri(kvs[:RemoteURL])
         kvs[:HTTPMethod] = SolarWindsAPM::Util.upcase(method)
         kvs
       rescue => e

--- a/lib/solarwinds_apm/inst/redis.rb
+++ b/lib/solarwinds_apm/inst/redis.rb
@@ -274,7 +274,7 @@ end
 
 if SolarWindsAPM::Config[:redis][:enabled]
   if defined?(::RedisClient)
-    SolarWindsAPM.logger.info "[solarwinds_apm/loading] Instrumenting redis #{Redis::VERSION}" if SolarWindsAPM::Config[:verbose]
+    SolarWindsAPM.logger.info "[solarwinds_apm/loading] Instrumenting redis through RedisClient #{RedisClient::VERSION}" if SolarWindsAPM::Config[:verbose]
     ::RedisClient.register(SolarWindsAPM::Inst::Redis::Client)
   end
 end

--- a/lib/solarwinds_apm/inst/typhoeus.rb
+++ b/lib/solarwinds_apm/inst/typhoeus.rb
@@ -37,7 +37,7 @@ module SolarWindsAPM
           # Conditionally log query params
           uri = URI(response.effective_url)
           kvs[:RemoteURL] = SolarWindsAPM::Config[:typhoeus][:log_args] ? uri.to_s : uri.to_s.split('?').first
-
+          kvs[:RemoteURL] = SolarWindsAPM::Util.sanitize_uri(kvs[:RemoteURL])
           response
         rescue => e
           SolarWindsAPM::API.log_exception(:typhoeus, e)

--- a/lib/solarwinds_apm/util.rb
+++ b/lib/solarwinds_apm/util.rb
@@ -114,6 +114,24 @@ module SolarWindsAPM
       end
 
       ##
+      # sanitize
+      #
+      # Remove the potential username and password from the uri user provided for reporting
+      def sanitize_uri(uri)
+        return uri if uri.nil?
+        begin
+          parsed_uri = URI.parse(uri)
+          parsed_uri.user = nil
+          sanitized_uri = parsed_uri.to_s
+        rescue StandardError => e
+          sanitized_uri = uri
+          SolarWindsAPM.logger.debug "[solarwinds_apm/debug] SolarWindsAPM::Util.sanitize_uri: could not sanitize #{uri}; caused by #{e.message}."
+        end
+        sanitized_uri
+      end
+
+
+      ##
       # upcase
       #
       # Occasionally, we want to send some values in all caps.  This is true

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -334,6 +334,21 @@ describe 'CurbTest' do # < Minitest::Test
     assert_equal "http://127.0.0.1:8101/",         traces[1]['RemoteURL']
   end
 
+  it 'curb discard username:password in url' do
+    c = nil
+
+    SolarWindsAPM::SDK.start_trace('curb_tests') do
+      c = Curl::Easy.new("http://admin:123456@127.0.0.1:8101/")
+      c.http_head
+    end
+
+    assert c.is_a?(::Curl::Easy), "Response type"
+    assert c.response_code == 200
+    assert c.header_str =~ /X-Trace/, "X-Trace response header"
+
+    assert_correct_traces('http://127.0.0.1:8101/', 'GET')
+  end
+
   it 'obey log args when true' do
     # When testing global config options, use the config_lock
     # semaphore to lock between other running tests.

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -295,4 +295,20 @@ describe "Typhoeus" do
     _(traces.count).must_equal 6
     layer_doesnt_have_key(traces, 'typhoeus', 'Backtrace')
   end
+
+  it 'typhoeus discard username:password from url' do
+    SolarWindsAPM::SDK.start_trace('typhoeus_test') do
+      Typhoeus.get("http://admin:123456@127.0.0.1:8101/")
+    end
+
+    traces = get_all_traces
+    _(traces.count).must_equal 6
+
+    _(valid_edges?(traces, false)).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    _(traces[4]['RemoteURL']).must_equal 'http://127.0.0.1:8101/'
+    _(traces[4]['HTTPMethod']).must_equal 'GET'
+    _(traces[4]['HTTPStatus']).must_equal 200
+  end
 end

--- a/test/run_tests/docker-compose.yml
+++ b/test/run_tests/docker-compose.yml
@@ -37,6 +37,8 @@ x-ao-env: &ao-env
   QUERY_LOG_FILE: "/tmp/sw_apm_query_logs.txt"
   RUBY_ENV: "test"
   TEST_RUNS_TO_FILE: "true"
+  SW_APM_DEBUG_LEVEL: 3
+  SW_APM_GEM_VERBOSE: true # for debug only
 
 x-ao-shared: &ao-shared
   mem_limit: 1G


### PR DESCRIPTION
## Why?
If customer/user provide the url with username and password (sasl authentication), then some of the library instrumentation will record it in kvs[:RemoteHost] or kvs[:RemoteURL], which is not good. The util function will take care of removing such sensitive information.

## Impact?
For RemoteURL, changed following libraries:
```
typeous
curb
http_client
```
